### PR TITLE
Extend libamf API with method to get # of tiles

### DIFF
--- a/Configfile
+++ b/Configfile
@@ -21,3 +21,11 @@ SOURCES     += lookup.c
 # The libamf test suite
 TESTSRC     += smiexample-addr.bash
 TESTSRC     += smiexample-size.bash
+
+# A command-line program thar parses AMF strings and uses the libamf API
+# to count the number of tiles, and print that number out.
+BINARIES    += amf-tilecount
+SOURCES     += tilecount.c
+TESTSRC     += single-tile.bash
+TESTSRC     += three-tile.bash
+

--- a/src/amf.h
+++ b/src/amf.h
@@ -26,6 +26,11 @@
 static __inline__
 const char *amf_lookup(const char *amf_string, const char *path);
 
+/* Returns the number of tiles implied in the given AMF-formatted string,
+ * or -1 if unable to find. */
+static __inline__ 
+int amf_ntiles (const char *amf_string);
+
 /* Everything below here is part of the AMF implementation.  For ease of use,
  * this is all stored in a single header file. */
 
@@ -152,5 +157,42 @@ const char *amf_lookup(const char *config_string, const char *path)
 
   return config_string;
 }
+
+/* Returns the number of tiles implied in the given AMF-formatted string,
+ * or -1 if unable to find. */
+static __inline__
+int amf_ntiles(const char *config_string)
+{
+  int ntiles;
+
+  config_string = amf_lookup(config_string, "core");
+  if (*config_string == '\0')
+    return -1;
+
+  config_string = _amf__advance_until_entered(config_string);
+  if (*config_string == '\0')
+    return -1;
+
+  ntiles = 0;
+  while (*config_string != '\0') {
+    config_string = _amf__advance_until_over(config_string);
+    while (*config_string != '\0' && _amf__isspace(*config_string))
+      config_string++;
+
+#ifdef AMF_DEBUG
+    fprintf(stderr, "Looking for tile '%d', in '%s'\n", ntiles, config_string);
+#endif
+    if (*config_string == '}') {
+      return ++ntiles;
+    } else if (*config_string != '\0') {
+      ntiles++;
+    } else {
+      return ntiles;
+    }
+  }
+
+  return ntiles;
+}
+
 
 #endif

--- a/src/tilecount.c
+++ b/src/tilecount.c
@@ -1,0 +1,51 @@
+/* Copyright 2016 Palmer Dabbelt <palmer@dabbelt.com> 
+ * Modifications by Eric Love <io@ericlove.me> from original lookup.c
+ */
+
+#include "amf.h"
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/types.h>
+
+int main()
+{
+  char *config_string;
+  size_t config_string_size;
+  size_t config_string_used;
+  int ntiles;
+
+  config_string_size = 1024;
+  config_string_used = 0;
+  config_string = malloc(config_string_size);
+  while (!feof(stdin)) {
+    ssize_t readed;
+
+    readed = fread(&config_string[config_string_used],
+                   1,
+                   config_string_size - config_string_used - 1,
+                   stdin);
+
+    if (readed < 0)
+      continue;
+
+    config_string_used += readed;
+    if (config_string_used > config_string_size / 2) {
+      char *new_config_string;
+      config_string_size *= 2;
+      new_config_string = realloc(config_string, config_string_size);
+      memcpy(new_config_string, config_string, config_string_used);
+      config_string = new_config_string;
+    }
+  }
+
+  config_string[config_string_used] = '\0';
+
+  ntiles = amf_ntiles(config_string);
+  if (ntiles < 0)
+    return 1;
+
+  printf("%d\n", ntiles);
+
+  return 0;
+}

--- a/test/amf-tilecount/_harness.bash
+++ b/test/amf-tilecount/_harness.bash
@@ -1,0 +1,3 @@
+$PTEST_BINARY < config_string > output
+
+diff -u output.gold output

--- a/test/amf-tilecount/_tempdir.bash
+++ b/test/amf-tilecount/_tempdir.bash
@@ -1,0 +1,5 @@
+tempdir=`mktemp -d -t pcad-memory_complier-tests.XXXXXXXXXX`
+trap "rm -rf $tempdir" EXIT
+
+set -ex
+cd $tempdir

--- a/test/amf-tilecount/single-tile.bash
+++ b/test/amf-tilecount/single-tile.bash
@@ -1,0 +1,53 @@
+#include "_tempdir.bash"
+
+cat > config_string <<EOF
+platform {
+  vendor ucb;
+  arch rocket;
+};
+plic {
+  priority 0x40000000;
+  pending 0x40001000;
+  ndevs 2;
+};
+rtc {
+  addr 0x2000;
+};
+ram {
+  0 {
+    addr 0x80000000;
+    size 0x80000000;
+  };
+};
+smiexample {
+  addr 0x48000000;
+  size 0x400;
+};
+core {
+  0 {
+    0 {
+      isa rv64imafd;
+      timecmp 0x2008;
+      ipi 0x44000000;
+      plic {
+        m {
+         ie 0x40002000;
+         thresh 0x40200000;
+         claim 0x40200004;
+        };
+        s {
+         ie 0x40002080;
+         thresh 0x40201000;
+         claim 0x40201004;
+        };
+      };
+    };
+  };
+};
+EOF
+
+cat >output.gold <<EOF
+1
+EOF
+
+#include "_harness.bash"

--- a/test/amf-tilecount/three-tile.bash
+++ b/test/amf-tilecount/three-tile.bash
@@ -1,0 +1,91 @@
+#include "_tempdir.bash"
+
+cat > config_string <<EOF
+platform {
+  vendor ucb;
+  arch rocket;
+};
+plic {
+  priority 0x40000000;
+  pending 0x40001000;
+  ndevs 2;
+};
+rtc {
+  addr 0x2000;
+};
+ram {
+  0 {
+    addr 0x80000000;
+    size 0x80000000;
+  };
+};
+smiexample {
+  addr 0x48000000;
+  size 0x400;
+};
+core {
+  0 {
+    0 {
+      isa rv64imafd;
+      timecmp 0x2008;
+      ipi 0x44000000;
+      plic {
+        m {
+         ie 0x40002000;
+         thresh 0x40200000;
+         claim 0x40200004;
+        };
+        s {
+         ie 0x40002080;
+         thresh 0x40201000;
+         claim 0x40201004;
+        };
+      };
+    };
+  };
+  1 {
+    0 {
+      isa rv64imafd;
+      timecmp 0x2008;
+      ipi 0x44000000;
+      plic {
+        m {
+         ie 0x40002000;
+         thresh 0x40200000;
+         claim 0x40200004;
+        };
+        s {
+         ie 0x40002080;
+         thresh 0x40201000;
+         claim 0x40201004;
+        };
+      };
+    };
+  };
+  2 {
+    0 {
+      isa rv64imafd;
+      timecmp 0x2008;
+      ipi 0x44000000;
+      plic {
+        m {
+         ie 0x40002000;
+         thresh 0x40200000;
+         claim 0x40200004;
+        };
+        s {
+         ie 0x40002080;
+         thresh 0x40201000;
+         claim 0x40201004;
+        };
+      };
+    };
+  };
+};
+EOF
+
+cat >output.gold <<EOF
+3
+EOF
+
+#include "_harness.bash"


### PR DESCRIPTION
This PR extends the libamf base API by adding a new function:

>  int amf_ntiles (const char *amf_string);

This uses the existing `amf_lookup()` function to parse a config string and count the number of tiles implied in the `cpu {}` block.  The committed code includes bot the function and two tests.

Since this changes the original philosophy of providing only a single function in the API, some justification is in order.  Consider the alternatives:
1. **Do nothing**: In this case, everyone who needs to find the number of tiles writes their own implementation, which seems wasteful and error-prone.
2. **Make a separate library** that includes common libamf "meta" functions like this one.  This seems needlessly complicated, and people will probably just rewrite that code instead of importing another project.

In light of this, I propose developing a standard API of ways to query higher-level AMF string attributes.  I've left out a function to count the number of cores, since that more controversially requires some white-box knowledge of tile structure, but I'll submit that as a separate PR so you can accept/reject it independently.
